### PR TITLE
[Feature] Add swagger api documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 			<artifactId>jjwt-api</artifactId>
 			<version>0.12.6</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.6</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/src/main/java/org/acelera/blogmaker/config/SecurityConfig.java
+++ b/src/main/java/org/acelera/blogmaker/config/SecurityConfig.java
@@ -1,5 +1,7 @@
-package org.acelera.blogmaker.security;
+package org.acelera.blogmaker.config;
 
+import org.acelera.blogmaker.security.JwtAuthenticationFilter;
+import org.acelera.blogmaker.security.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -36,7 +38,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/auth/register").permitAll()
                         .requestMatchers("/api/v1/auth/login").permitAll()
-                        .requestMatchers(HttpMethod.GET, API_POSTS).permitAll()
+                        .requestMatchers("/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-resources/**",
+                                "/swagger-ui.html")
+                        .permitAll()
+                        .requestMatchers(HttpMethod.GET, API_POSTS).authenticated()
                         .requestMatchers(HttpMethod.POST, API_POSTS).authenticated()
                         .requestMatchers(HttpMethod.PUT, API_POSTS).authenticated()
                         .requestMatchers(HttpMethod.DELETE, API_POSTS).authenticated()

--- a/src/main/java/org/acelera/blogmaker/config/SwaggerConfig.java
+++ b/src/main/java/org/acelera/blogmaker/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package org.acelera.blogmaker.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SecurityScheme(
+        name = "BearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+@OpenAPIDefinition(
+        info = @Info(
+                title = "BlogMaker API",
+                version = "1.0",
+                description = "API BlogMaker - Um blog para desenvolvedores",
+                contact = @Contact(
+                        name = "João Paulo Almeida",
+                        email = "contato.joaopaulodeveloper@gmail.com"
+                )
+        ),
+        security = {@SecurityRequirement(name = "BearerAuth")},
+        servers = {
+                @Server(url = "http://localhost:8080", description = "Servidor local")
+        }
+)
+public class SwaggerConfig {}


### PR DESCRIPTION
## Descrição (resolved: #17)
Esse pull request inclui várias alterações para adicionar suporte ao Swagger/OpenAPI e atualizar a configuração de segurança. As mudanças mais importantes incluem a adição de uma nova dependência para o Swagger, a renomeação e atualização da classe `SecurityConfig` e a criação de uma nova classe `SwaggerConfig`.

### Suporte ao Swagger/OpenAPI:

* Adicionada a dependência `springdoc-openapi-starter-webmvc-ui` no `pom.xml` para suportar o Swagger UI.
* Criada uma nova classe `SwaggerConfig` para configurar o Swagger com definições OpenAPI e esquemas de segurança.

### Configuração de Segurança:

* Renomeada a `SecurityConfig` de `org.acelera.blogmaker.security` para `org.acelera.blogmaker.config` e atualizados os imports de pacotes de acordo.
* Atualizado o método `securityFilterChain` na `SecurityConfig` para permitir acesso aos endpoints relacionados ao Swagger e exigir autenticação para requisições GET a `API_POSTS`.
