### PR TITLE
[Fix]: Update test configurations and improve dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -120,6 +122,13 @@
 							<version>1.18.38</version>
 						</path>
 					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,9 +1,7 @@
-# Banco em memória para testes
 spring.datasource.url=jdbc:h2:mem:blogmaker_test;DB_CLOSE_DELAY=-1
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 
-# Configurações JWT para testes (chave e expiração fictícias)
 jwt.secret=testsecret
 jwt.expiration=3600

--- a/src/test/java/org/acelera/blogmaker/service/integration/PostServiceIntegrationTest.java
+++ b/src/test/java/org/acelera/blogmaker/service/integration/PostServiceIntegrationTest.java
@@ -26,9 +26,9 @@ class PostServiceIntegrationTest {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
 
-    public PostServiceIntegrationTest(@Autowired PostService postService,
-                                    @Autowired UserRepository userRepository,
-                                    @Autowired PostRepository postRepository) {
+    @Autowired
+    public PostServiceIntegrationTest(PostService postService, UserRepository userRepository,
+                                    PostRepository postRepository) {
         this.postService = postService;
         this.userRepository = userRepository;
         this.postRepository = postRepository;

--- a/src/test/java/org/acelera/blogmaker/service/integration/ThemeServiceIntegrationTest.java
+++ b/src/test/java/org/acelera/blogmaker/service/integration/ThemeServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import org.acelera.blogmaker.model.dto.response.ThemeResponse;
 import org.acelera.blogmaker.repository.ThemeRepository;
 import org.acelera.blogmaker.services.ThemeService;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ class ThemeServiceIntegrationTest {
     private final ThemeService themeService;
     private final ThemeRepository themeRepository;
 
+    @Autowired
     public ThemeServiceIntegrationTest(ThemeService themeService, ThemeRepository themeRepository) {
         this.themeService = themeService;
         this.themeRepository = themeRepository;

--- a/src/test/java/org/acelera/blogmaker/service/integration/UserServiceIntegrationTest.java
+++ b/src/test/java/org/acelera/blogmaker/service/integration/UserServiceIntegrationTest.java
@@ -28,7 +28,8 @@ class UserServiceIntegrationTest {
     private final UserService userService;
     private final UserRepository userRepository;
 
-    UserServiceIntegrationTest(@Autowired UserService userService, @Autowired UserRepository userRepository) {
+    @Autowired
+    UserServiceIntegrationTest(UserService userService, UserRepository userRepository) {
         this.userService = userService;
         this.userRepository = userRepository;
     }

--- a/src/test/java/org/acelera/blogmaker/service/unit/UserServiceTest.java
+++ b/src/test/java/org/acelera/blogmaker/service/unit/UserServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.List;
 
+
 class UserServiceTest {
 
     @Mock


### PR DESCRIPTION
## Descrição (resolved: #21)
Este pull request inclui várias mudanças para melhorar as configurações de codificação, atualizar dependências e aprimorar as anotações das classes de teste.

### Atualizações de Codificação e Dependências:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R31-R32): Adicionadas configurações de codificação UTF-8 para o código-fonte e para os relatórios, além da inclusão do `maven-resources-plugin` com configuração de codificação UTF-8. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R31-R32) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R127-R133)

### Configuração de Teste e Anotações:

* [`src/main/resources/application-test.properties`](diffhunk://#diff-7262e6545724c8dbe1b3c64b35b6f9b737cf0aaf7242725378a0d6574e6bed19L1-L7): Removidos comentários com codificação incorreta.
* [`src/test/java/org/acelera/blogmaker/service/integration/PostServiceIntegrationTest.java`](diffhunk://#diff-ca16f8cfbe133d4ace1b882f3f0a4ec6cd93685e374b0ea70ac5feb51dc3a709L29-R31): Adicionada a anotação `@Autowired` ao construtor.
* [`src/test/java/org/acelera/blogmaker/service/integration/ThemeServiceIntegrationTest.java`](diffhunk://#diff-cf2659dfc77a8342c36515b1b227c8d674f5b6d9d2bdb3a8b2e813f5fd65a946R11): Importada a anotação `@Autowired` e adicionada ao construtor. [[1]](diffhunk://#diff-cf2659dfc77a8342c36515b1b227c8d674f5b6d9d2bdb3a8b2e813f5fd65a946R11) [[2]](diffhunk://#diff-cf2659dfc77a8342c36515b1b227c8d674f5b6d9d2bdb3a8b2e813f5fd65a946R27)
* [`src/test/java/org/acelera/blogmaker/service/integration/UserServiceIntegrationTest.java`](diffhunk://#diff-e3dd89646fab114024833afe29970d70a4094685b04322af2bc864aa41eff1c3L31-R32): Adicionada a anotação `@Autowired` ao construtor.
* [`src/test/java/org/acelera/blogmaker/service/unit/UserServiceTest.java`](diffhunk://#diff-2aaa59ee8b3973547c7f7b72a6f2ea606eb24286f29f081bbfde0bf0b750af60R27): Adicionada uma linha em branco para melhor legibilidade.