### PR TITLE
[Feature] Global exception handler

### DIFF
--- a/src/main/java/org/acelera/blogmaker/exception/PostAlreadyExistException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/PostAlreadyExistException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
 public class PostAlreadyExistException extends RuntimeException {
     public PostAlreadyExistException(String message) {
         super(message);

--- a/src/main/java/org/acelera/blogmaker/exception/PostNotFoundException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/PostNotFoundException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class PostNotFoundException extends RuntimeException {
     public PostNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/acelera/blogmaker/exception/ThemeAlreadyExistException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/ThemeAlreadyExistException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
 public class ThemeAlreadyExistException extends RuntimeException {
     public ThemeAlreadyExistException(String message) {
         super(message);

--- a/src/main/java/org/acelera/blogmaker/exception/ThemeNotFoundException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/ThemeNotFoundException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class ThemeNotFoundException extends RuntimeException {
     public ThemeNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/acelera/blogmaker/exception/UserAlreadyExistException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/UserAlreadyExistException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
 public class UserAlreadyExistException extends RuntimeException {
 
     public UserAlreadyExistException(String message) {

--- a/src/main/java/org/acelera/blogmaker/exception/UserNotFoundException.java
+++ b/src/main/java/org/acelera/blogmaker/exception/UserNotFoundException.java
@@ -1,5 +1,9 @@
 package org.acelera.blogmaker.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/acelera/blogmaker/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/acelera/blogmaker/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,135 @@
+package org.acelera.blogmaker.exception.handler;
+
+import org.acelera.blogmaker.exception.PostAlreadyExistException;
+import org.acelera.blogmaker.exception.PostNotFoundException;
+import org.acelera.blogmaker.exception.ThemeAlreadyExistException;
+import org.acelera.blogmaker.exception.ThemeNotFoundException;
+import org.acelera.blogmaker.exception.UserAlreadyExistException;
+import org.acelera.blogmaker.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePostNotFound(PostNotFoundException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler(ThemeNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleThemeNotFound(ThemeNotFoundException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler(PostAlreadyExistException.class)
+    public ResponseEntity<ErrorResponse> handlePostAlreadyExists(PostAlreadyExistException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.CONFLICT, request);
+    }
+
+    @ExceptionHandler(ThemeAlreadyExistException.class)
+    public ResponseEntity<ErrorResponse> handleThemeAlreadyExists(ThemeAlreadyExistException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.CONFLICT, request);
+    }
+
+    @ExceptionHandler(UserAlreadyExistException.class)
+    public ResponseEntity<ErrorResponse> handleUserAlreadyExists(UserAlreadyExistException ex, WebRequest request) {
+        return createErrorResponse(ex.getMessage(), HttpStatus.CONFLICT, request);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        }));
+
+        ValidationErrorResponse errorResponse = new ValidationErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation failed",
+                LocalDateTime.now(),
+                request.getDescription(false),
+                errors
+        );
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(WebRequest request) {
+        return createErrorResponse(
+                "An unexpected error occurred",
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                request
+        );
+    }
+
+    private ResponseEntity<ErrorResponse> createErrorResponse(String message, HttpStatus status, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                status.value(),
+                message,
+                LocalDateTime.now(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, status);
+    }
+
+    public static class ErrorResponse {
+        private final int status;
+        private final String message;
+        private final LocalDateTime timestamp;
+        private final String path;
+
+        public ErrorResponse(int status, String message, LocalDateTime timestamp, String path) {
+            this.status = status;
+            this.message = message;
+            this.timestamp = timestamp;
+            this.path = path;
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public LocalDateTime getTimestamp() {
+            return timestamp;
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+
+    public static class ValidationErrorResponse extends ErrorResponse {
+        private final Map<String, String> errors;
+
+        public ValidationErrorResponse(int status, String message, LocalDateTime timestamp, String path, Map<String, String> errors) {
+            super(status, message, timestamp, path);
+            this.errors = errors;
+        }
+
+        public Map<String, String> getErrors() {
+            return errors;
+        }
+    }
+}


### PR DESCRIPTION
# Descrição

Esta pull request introduz um mecanismo global de tratamento de exceções e atualiza várias exceções customizadas para retornar códigos de status HTTP específicos. As mudanças mais importantes incluem a adição de anotações `@ResponseStatus` às exceções customizadas e a implementação de uma classe `GlobalExceptionHandler` para tratar diversas exceções de forma centralizada.

## Atualização das Exceções Customizadas

- [`src/main/java/org/acelera/blogmaker/exception/PostAlreadyExistException.java`](diffhunk://#diff-fc2fc5035d38e927c9cd8f20871da09c9f88ee0169adc58746fe149fd179de3aR3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.CONFLICT)` para indicar um status de conflito quando esta exceção é lançada.
- [`src/main/java/org/acelera/blogmaker/exception/PostNotFoundException.java`](diffhunk://#diff-704d8cfdb6387c75c683b5d84390fc63843239d7a794a2017aaced1aae91b099R3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.NOT_FOUND)` para indicar um status de "não encontrado" quando esta exceção é lançada.
- [`src/main/java/org/acelera/blogmaker/exception/ThemeAlreadyExistException.java`](diffhunk://#diff-f0ca3144b3fbdb23d2af12505ba5efd78e0c35832b653ed0da6241c349808476R3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.CONFLICT)` para indicar um status de conflito quando esta exceção é lançada.
- [`src/main/java/org/acelera/blogmaker/exception/ThemeNotFoundException.java`](diffhunk://#diff-95558c9dd53b0ba6b0251fd9371fffc1eb658f4f399549c324a41f308e134a4dR3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.NOT_FOUND)` para indicar um status de "não encontrado" quando esta exceção é lançada.
- [`src/main/java/org/acelera/blogmaker/exception/UserAlreadyExistException.java`](diffhunk://#diff-c8253c001db42dde227b476f275bae50f0cae85e8e1902fd955874f7a5c6bc7aR3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.CONFLICT)` para indicar um status de conflito quando esta exceção é lançada.
- [`src/main/java/org/acelera/blogmaker/exception/UserNotFoundException.java`](diffhunk://#diff-5b6ab6a3b068d619d409648edea9b11110e62d29e6ab1f7d3d87158e6f64aa93R3-R6): Adicionada a anotação `@ResponseStatus(HttpStatus.NOT_FOUND)` para indicar um status de "não encontrado" quando esta exceção é lançada.

## Tratamento Global de Exceções

- [`src/main/java/org/acelera/blogmaker/exception/handler/GlobalExceptionHandler.java`](diffhunk://#diff-c34e555a1a4ac52caf819ade0cfe23e8154644b5579ff0df19054cf5067a4396R1-R135): Introduzida uma nova classe `GlobalExceptionHandler` para centralizar o tratamento de exceções. Esta classe inclui métodos para tratar exceções específicas (`PostNotFoundException`, `ThemeNotFoundException`, `UserNotFoundException`, `PostAlreadyExistException`, `ThemeAlreadyExistException`, `UserAlreadyExistException`, `MethodArgumentNotValidException` e uma exceção genérica `Exception`). Cada método retorna uma `ErrorResponse` ou `ValidationErrorResponse` estruturada com os códigos de status HTTP relevantes e detalhes dos erros.
