### PR TITLE
[chore] Update SonarQube configuration and add JaCoCo plugin for code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,12 +30,7 @@
 		<java.version>21</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<sonar.token>squ_02ba5e5f409b96bff03222f3a33bb2dfbf7f4a79</sonar.token>
-		<sonar.projectKey>blog-maker</sonar.projectKey>
-		<sonar.projectName>Blog Maker</sonar.projectName>
-		<sonar.host.url>http://localhost:9000</sonar.host.url>
-		<sonar.tests>src/test/java</sonar.tests>
-		<sonar.sources>src/main/java</sonar.sources>
+		<sonar.token>${sonar.token}</sonar.token>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -136,6 +131,25 @@
 				<configuration>
 					<encoding>UTF-8</encoding>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.10</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,11 @@
-sonar.projectKey=blog-maker
+sonar.projectKey=blogMaker
 sonar.projectName=Blog Maker
+sonar.projectVersion=1.0
 sonar.host.url=http://localhost:9000
-sonar.token=squ_02ba5e5f409b96bff03222f3a33bb2dfbf7f4a79
-sonar.language=java
+
 sonar.sourceEncoding=UTF-8
 sonar.sources=src/main/java
+
 sonar.tests=src/test/java
 sonar.java.binaries=target/classes
+sonar.junit.reportPaths=target/surefire-reports


### PR DESCRIPTION
## Descrição

Esta pull request inclui alterações nos arquivos `pom.xml` e `sonar-project.properties` para aprimorar a gestão de configuração e adicionar relatórios de cobertura de código. As mudanças mais importantes incluem a remoção de propriedades hardcoded do SonarQube, a adição do plugin Maven JaCoCo para cobertura de código e atualizações nas propriedades do projeto SonarQube.

## Melhorias na Gestão de Configuração

- [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L33-R33): Foram removidas as propriedades do SonarQube fixas e substituídas por placeholders para permitir uma configuração dinâmica.
- [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL1-R11): Atualizado o `sonar.projectKey` para usar camel case e adicionada a propriedade `sonar.projectVersion` para especificar a versão do projeto.

## Relatórios de Cobertura de Código

- [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R135-R153): Adicionado o plugin Maven JaCoCo para gerar relatórios de cobertura de código durante o processo de build.
- [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL1-R11): Adicionada a propriedade `sonar.junit.reportPaths` para especificar a localização dos arquivos de relatório do JUnit para análise do SonarQube.
