### PR TITLE
[Fix] User info authentication context and dtos changes

### DIFF
--- a/src/main/java/org/acelera/blogmaker/config/SecurityConfig.java
+++ b/src/main/java/org/acelera/blogmaker/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
     private final UserDetailsServiceImpl userDetailsService;
     private final JwtAuthenticationFilter jwtAuthFilter;
     private static final String API_POSTS = "/api/v1/posts/**";
+    private static final String API_ANALYTICS = "/api/v1/analytics/**";
 
     public SecurityConfig( UserDetailsServiceImpl userDetailsService, JwtAuthenticationFilter jwtAuthFilter) {
         this.userDetailsService = userDetailsService;
@@ -50,12 +51,15 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/swagger-ui.html")
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, API_POSTS).permitAll()
-                        .requestMatchers(HttpMethod.POST, API_POSTS).permitAll()
-                        .requestMatchers(HttpMethod.PUT, API_POSTS).permitAll()
-                        .requestMatchers(HttpMethod.DELETE, API_POSTS).permitAll()
+                        .requestMatchers(HttpMethod.GET, API_ANALYTICS).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/posts/{id}").permitAll()
+                        .requestMatchers(HttpMethod.GET, API_POSTS).authenticated()
+                        .requestMatchers(HttpMethod.POST, API_POSTS).authenticated()
+                        .requestMatchers(HttpMethod.PUT, API_POSTS).authenticated()
+                        .requestMatchers(HttpMethod.DELETE, API_POSTS).authenticated()
                         .requestMatchers("/api/v1/auth/admin/**").hasRole("OWNER")
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/org/acelera/blogmaker/controller/v1/AuthController.java
+++ b/src/main/java/org/acelera/blogmaker/controller/v1/AuthController.java
@@ -2,9 +2,11 @@ package org.acelera.blogmaker.controller.v1;
 
 import jakarta.validation.Valid;
 import org.acelera.blogmaker.model.Role;
+import org.acelera.blogmaker.model.User;
 import org.acelera.blogmaker.model.dto.request.AuthRequest;
 import org.acelera.blogmaker.model.dto.request.CreateUserRequest;
 import org.acelera.blogmaker.model.dto.response.AuthResponse;
+import org.acelera.blogmaker.model.dto.response.UserDto;
 import org.acelera.blogmaker.security.JwtUtil;
 import org.acelera.blogmaker.security.UserDetailsImpl;
 import org.acelera.blogmaker.services.UserService;
@@ -39,7 +41,11 @@ public class AuthController {
 
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
         String token = jwtUtil.generateToken(userDetails);
-        return ResponseEntity.ok(new AuthResponse(token));
+        
+        User user = userService.findByEmail(userDetails.getUsername());
+        UserDto userDto = new UserDto(user);
+        
+        return ResponseEntity.ok(new AuthResponse(token, userDto));
     }
 
     @PostMapping("/register")
@@ -56,6 +62,7 @@ public class AuthController {
         var user = userService.createUser(request, role);
         UserDetailsImpl userDetails = new UserDetailsImpl(user);
         String token = jwtUtil.generateToken(userDetails);
-        return ResponseEntity.ok(new AuthResponse(token));
+        UserDto userDto = new UserDto(user);
+        return ResponseEntity.ok(new AuthResponse(token, userDto));
     }
 }

--- a/src/main/java/org/acelera/blogmaker/controller/v1/PostController.java
+++ b/src/main/java/org/acelera/blogmaker/controller/v1/PostController.java
@@ -5,8 +5,11 @@ import jakarta.validation.Valid;
 import org.acelera.blogmaker.model.dto.request.CreatePostRequest;
 import org.acelera.blogmaker.model.dto.request.UpdatePostRequest;
 import org.acelera.blogmaker.model.dto.response.PostResponse;
+import org.acelera.blogmaker.security.UserDetailsImpl;
 import org.acelera.blogmaker.services.PostService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -27,7 +30,11 @@ public class PostController {
     @PostMapping
     @Transactional
     public ResponseEntity<Void> createPost(@Valid @RequestBody CreatePostRequest request) {
-        Long postId = postService.createPost(request, request.userId(), request.themeId());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        UUID userId = userDetails.getId();
+
+        Long postId = postService.createPost(request, userId, request.themeId());
 
         return ResponseEntity.created(URI.create("/api/v1/posts/" + postId)).build();
     }

--- a/src/main/java/org/acelera/blogmaker/model/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/acelera/blogmaker/model/dto/request/CreatePostRequest.java
@@ -1,9 +1,6 @@
 package org.acelera.blogmaker.model.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
-import java.util.UUID;
 
 public record CreatePostRequest(
         @NotBlank(message = "{required.title}")
@@ -12,9 +9,6 @@ public record CreatePostRequest(
         @NotBlank(message = "{required.content}")
         String content,
 
-        Long themeId,
-
-        @NotNull(message = "{required.user}")
-        UUID userId
+        Long themeId
 ) {
 }

--- a/src/main/java/org/acelera/blogmaker/model/dto/response/AuthResponse.java
+++ b/src/main/java/org/acelera/blogmaker/model/dto/response/AuthResponse.java
@@ -1,17 +1,4 @@
 package org.acelera.blogmaker.model.dto.response;
 
-public class AuthResponse {
-    private String token;
-
-    public AuthResponse(String token) {
-        this.token = token;
-    }
-
-    public String getToken() {
-        return token;
-    }
-
-    public void setToken(String token) {
-        this.token = token;
-    }
+public record AuthResponse(String token, UserDto user) {
 }

--- a/src/main/java/org/acelera/blogmaker/model/dto/response/UserDto.java
+++ b/src/main/java/org/acelera/blogmaker/model/dto/response/UserDto.java
@@ -1,0 +1,11 @@
+package org.acelera.blogmaker.model.dto.response;
+
+import org.acelera.blogmaker.model.User;
+
+import java.util.UUID;
+
+public record UserDto(UUID id, String name, String email, String role, String photo) {
+    public UserDto(User user) {
+        this(user.getId(), user.getName(), user.getEmail(), user.getRole().name(), user.getPhoto());
+    }
+} 

--- a/src/main/java/org/acelera/blogmaker/security/JwtUtil.java
+++ b/src/main/java/org/acelera/blogmaker/security/JwtUtil.java
@@ -56,6 +56,12 @@ public class JwtUtil {
 
     public String generateToken(UserDetails userDetails) {
         Map<String, Object> claims = new HashMap<>();
+        
+        if (userDetails instanceof UserDetailsImpl) {
+            UserDetailsImpl userDetailsImpl = (UserDetailsImpl) userDetails;
+            claims.put("userId", userDetailsImpl.getId().toString());
+        }
+        
         return createToken(claims, userDetails.getUsername());
     }
 

--- a/src/main/java/org/acelera/blogmaker/security/UserDetailsImpl.java
+++ b/src/main/java/org/acelera/blogmaker/security/UserDetailsImpl.java
@@ -7,16 +7,19 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 public class UserDetailsImpl implements UserDetails {
     private final String email;
     private final String password;
     private final Collection<? extends GrantedAuthority> authorities;
+    private final UUID id;
 
     public UserDetailsImpl(User user) {
         this.email = user.getEmail();
         this.password = user.getPassword();
         this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+        this.id = user.getId();
     }
 
     @Override
@@ -32,6 +35,10 @@ public class UserDetailsImpl implements UserDetails {
     @Override
     public String getUsername() {
         return email;
+    }
+    
+    public UUID getId() {
+        return id;
     }
 
     @Override

--- a/src/main/java/org/acelera/blogmaker/services/UserService.java
+++ b/src/main/java/org/acelera/blogmaker/services/UserService.java
@@ -79,4 +79,9 @@ public class UserService {
 
         repository.deleteById(userId);
     }
+    
+    public User findByEmail(String email) {
+        return repository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found with email: " + email));
+    }
 }

--- a/src/test/java/org/acelera/blogmaker/service/unit/PostServiceTest.java
+++ b/src/test/java/org/acelera/blogmaker/service/unit/PostServiceTest.java
@@ -3,10 +3,7 @@ package org.acelera.blogmaker.service.unit;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import org.acelera.blogmaker.exception.PostAlreadyExistException;
-import org.acelera.blogmaker.exception.PostNotFoundException;
-import org.acelera.blogmaker.exception.ThemeNotFoundException;
-import org.acelera.blogmaker.exception.UserNotFoundException;
+import org.acelera.blogmaker.exception.*;
 import org.acelera.blogmaker.model.Post;
 import org.acelera.blogmaker.model.Role;
 import org.acelera.blogmaker.model.Theme;
@@ -21,32 +18,20 @@ import org.acelera.blogmaker.services.PostService;
 import org.acelera.blogmaker.services.mapper.PostMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.time.LocalDateTime;
 
 class PostServiceTest {
 
-    @Mock
-    private PostRepository repository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private ThemeRepository themeRepository;
-
-    @Mock
-    private PostMapper mapper;
-
-    @InjectMocks
-    private PostService postService;
+    @Mock private PostRepository repository;
+    @Mock private UserRepository userRepository;
+    @Mock private ThemeRepository themeRepository;
+    @Mock private PostMapper mapper;
+    @InjectMocks private PostService postService;
 
     @BeforeEach
     void setup() {
@@ -55,54 +40,47 @@ class PostServiceTest {
 
     @Test
     void createPost_ShouldThrowUserNotFound_WhenUserDoesNotExist() {
-        CreatePostRequest request = new CreatePostRequest("Title", "Content", 1L, UUID.randomUUID());
-        UUID userId = request.userId();
-        Long themeId = request.themeId();
-
+        UUID userId = UUID.randomUUID();
+        long themeId = 1L;
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", themeId);
         when(userRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
 
-        UserNotFoundException exception = assertThrows(UserNotFoundException.class, () ->
+        assertThrows(UserNotFoundException.class, () ->
                 postService.createPost(request, userId, themeId)
         );
-        assertTrue(exception.getMessage().contains("User not found"));
     }
 
     @Test
     void createPost_ShouldThrowThemeNotFound_WhenThemeDoesNotExist() {
         UUID userId = UUID.randomUUID();
-        CreatePostRequest request = new CreatePostRequest("Title", "Content", 1L, userId);
-        Long themeId = request.themeId();
+        long themeId = 1L;
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", themeId);
         User user = new User();
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(themeRepository.findById(1L)).thenReturn(Optional.empty());
+        when(themeRepository.findById(themeId)).thenReturn(Optional.empty());
 
-        ThemeNotFoundException exception = assertThrows(ThemeNotFoundException.class, () ->
+        assertThrows(ThemeNotFoundException.class, () ->
                 postService.createPost(request, userId, themeId)
         );
-        assertTrue(exception.getMessage().contains("Theme not found"));
     }
 
     @Test
     void createPost_ShouldThrowPostAlreadyExistException_WhenTitleAndContentExist() {
         UUID userId = UUID.randomUUID();
-        CreatePostRequest request = new CreatePostRequest("Title", "Content", null, userId);
-        Long themeId = request.themeId();
-        User user = new User();
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", null);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(new User()));
         when(repository.existsByTitle("Title")).thenReturn(true);
         when(repository.existsByContent("Content")).thenReturn(true);
 
-        PostAlreadyExistException exception = assertThrows(PostAlreadyExistException.class, () ->
-                postService.createPost(request, userId, themeId)
+        assertThrows(PostAlreadyExistException.class, () ->
+                postService.createPost(request, userId, request.themeId())
         );
-        assertTrue(exception.getMessage().contains("Post already exists"));
     }
 
     @Test
     void createPost_ShouldReturnPostId_WhenSuccessful() {
         UUID userId = UUID.randomUUID();
-        CreatePostRequest request = new CreatePostRequest("Title", "Content", null, userId);
-        Long themeId = request.themeId();
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", null);
         User user = new User();
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(repository.existsByTitle("Title")).thenReturn(false);
@@ -113,98 +91,64 @@ class PostServiceTest {
         when(mapper.toPost(request, user, null)).thenReturn(post);
         when(repository.save(post)).thenReturn(post);
 
-        Long postId = postService.createPost(request, userId, themeId);
+        Long postId = postService.createPost(request, userId, request.themeId());
+
         assertEquals(100L, postId);
     }
 
     @Test
     void getPostById_ShouldThrowPostNotFoundException_WhenPostDoesNotExist() {
         when(repository.findById(1L)).thenReturn(Optional.empty());
-        PostNotFoundException exception = assertThrows(PostNotFoundException.class, () ->
+        assertThrows(PostNotFoundException.class, () ->
                 postService.getPostById(1L)
         );
-        assertTrue(exception.getMessage().contains("Post not found"));
     }
 
     @Test
     void updatePost_ShouldThrowPostNotFoundException_WhenPostDoesNotExist() {
         UpdatePostRequest request = new UpdatePostRequest("New Title", "New Content", null);
-        Long themeId = request.themeId();
         when(repository.findById(1L)).thenReturn(Optional.empty());
-        PostNotFoundException exception = assertThrows(PostNotFoundException.class, () ->
-                postService.updatePost(request, 1L, themeId)
+        assertThrows(PostNotFoundException.class, () ->
+                postService.updatePost(request, 1L, request.themeId())
         );
-        assertTrue(exception.getMessage().contains("Post not found"));
     }
 
     @Test
     void updatePost_ShouldThrowThemeNotFoundException_WhenThemeDoesNotExist() {
         UpdatePostRequest request = new UpdatePostRequest("New Title", "New Content", 1L);
-        Long themeId = request.themeId();
-        Post existingPost = new Post();
-        when(repository.findById(1L)).thenReturn(Optional.of(existingPost));
-        when(themeRepository.findById(1L)).thenReturn(Optional.empty());
-        ThemeNotFoundException exception = assertThrows(ThemeNotFoundException.class, () ->
-                postService.updatePost(request, 1L, themeId)
+        when(repository.findById(1L)).thenReturn(Optional.of(new Post()));
+        when(themeRepository.findById(request.themeId())).thenReturn(Optional.empty());
+        assertThrows(ThemeNotFoundException.class, () ->
+                postService.updatePost(request, 1L, request.themeId())
         );
-        assertTrue(exception.getMessage().contains("Theme not found"));
     }
 
     @Test
     void deletePost_ShouldThrowPostNotFoundException_WhenPostDoesNotExist() {
         when(repository.findById(1L)).thenReturn(Optional.empty());
-        PostNotFoundException exception = assertThrows(PostNotFoundException.class, () ->
+        assertThrows(PostNotFoundException.class, () ->
                 postService.deletePost(1L)
         );
-        assertTrue(exception.getMessage().contains("Post not found"));
     }
 
     @Test
     void filterPosts_ShouldReturnAllPosts_WhenNoFilter() {
-        Theme theme = Theme.builder()
-                .id(1L)
-                .description("Theme")
-                .build();
-        User user = User.builder()
-                .id(UUID.randomUUID())
-                .name("User Name")
-                .email("user@example.com")
-                .password("password")
-                .photo("photo.png")
-                .role(Role.USER)
-                .build();
-
+        Theme theme = Theme.builder().id(1L).description("Theme").build();
+        User user = User.builder().id(UUID.randomUUID()).name("User Name").email("user@example.com")
+                .password("password").photo("photo.png").role(Role.USER).build();
         LocalDateTime now = LocalDateTime.now();
-        Post post = Post.builder()
-                .id(1L)
-                .title("Title")
-                .content("Content")
-                .createdAt(now)
-                .updatedAt(now)
-                .theme(theme)
-                .user(user)
-                .build();
-
+        Post post = Post.builder().id(1L).title("Title").content("Content").createdAt(now)
+                .updatedAt(now).theme(theme).user(user).build();
         PostResponse response = new PostResponse(
-                1L,
-                "Title",
-                "Content",
-                now,
-                now,
-                "Theme",
-                1L,
-                "User Name",
-                user.getId(),
-                "USER",
-                "photo.png"
+                1L, "Title", "Content", now, now,
+                "Theme", 1L, "User Name",
+                user.getId(), "USER", "photo.png"
         );
-
         when(repository.findAll()).thenReturn(Collections.singletonList(post));
         when(mapper.fromPost(post)).thenReturn(response);
 
-        List<PostResponse> result = postService.getAllPosts();
-
-        assertEquals(1, result.size(), "Deve retornar exatamente um post");
-        assertEquals("Title", result.getFirst().title(), "O título deve ser 'Title'");
+        var result = postService.getAllPosts();
+        assertEquals(1, result.size());
+        assertEquals("Title", result.getFirst().title());
     }
 }


### PR DESCRIPTION
## Descrição (close: #34)
Este pull request introduz várias mudanças significativas para aprimorar a segurança, melhorar funcionalidades relacionadas ao usuário e refatorar o código para melhor manutenção. As atualizações principais incluem ajustes na configuração de segurança, modificações na autenticação e no tratamento de usuários, e atualizações na estrutura de `CreatePostRequest` e testes relacionados.

### Atualizações na Configuração de Segurança:
* Adicionada uma nova constante de endpoint de API `API_ANALYTICS` à classe `SecurityConfig` e atualizadas as regras de segurança para permitir acesso não autenticado aos endpoints de analytics, enquanto exigem autenticação para a maioria dos endpoints `API_POSTS`. (`src/main/java/org/acelera/blogmaker/config/SecurityConfig.java`) [[1]](diffhunk://#diff-e157e8d9161d471e9609971ec9634906af0fa07d1dd8a95836aa45779abe3f38R34) [[2]](diffhunk://#diff-e157e8d9161d471e9609971ec9634906af0fa07d1dd8a95836aa45779abe3f38L53-R62)

### Melhorias na Autenticação e no Usuário:
* Atualizada a classe `AuthResponse` para incluir detalhes do usuário (`UserDto`) juntamente com o token, e modificados os métodos `login` e `register` em `AuthController` para retornar essa resposta enriquecida. (`src/main/java/org/acelera/blogmaker/controller/v1/AuthController.java`, `src/main/java/org/acelera/blogmaker/model/dto/response/AuthResponse.java`, `src/main/java/org/acelera/blogmaker/model/dto/response/UserDto.java`) [[1]](diffhunk://#diff-09b09e3937c3d6607063942c9a5ad32c25b3315a3f3ff40399253fba07d6477cL42-R48) [[2]](diffhunk://#diff-09b09e3937c3d6607063942c9a5ad32c25b3315a3f3ff40399253fba07d6477cL59-R66) [[3]](diffhunk://#diff-66513514722e9b4c34e2edad9e3148bcf8d22300158d292ad96dd41f8f0f52ecL3-R3) [[4]](diffhunk://#diff-674b3d089e01bfed7968b58d4e27fcc34ac7bb044094a35e3e912d885b29694eR1-R11)
* Aprimorado o `JwtUtil` para incluir o ID do usuário nas claims dos tokens gerados e adicionando um método `getId` ao `UserDetailsImpl` para recuperar o ID do usuário. (`src/main/java/org/acelera/blogmaker/security/JwtUtil.java`, `src/main/java/org/acelera/blogmaker/security/UserDetailsImpl.java`) [[1]](diffhunk://#diff-416b5e585942354083834124c6ca1fac89336c3ece9bf3cc302e725f6fe70b67R59-R64) [[2]](diffhunk://#diff-b09cf9eb0e9829bb16639cb0ec59606175ee63746f26fc9c38f48f1cf570a843R10-R22) [[3]](diffhunk://#diff-b09cf9eb0e9829bb16639cb0ec59606175ee63746f26fc9c38f48f1cf570a843R40-R43)
* Adicionado método `findByEmail` ao `UserService` para buscar detalhes do usuário por e-mail. (`src/main/java/org/acelera/blogmaker/services/UserService.java`)

### Criação de Post e Refatoração de Requisições:
* Removido o campo `userId` da classe `CreatePostRequest` e atualizado o `PostController` para usar o ID do usuário autenticado na criação de postagens. (`src/main/java/org/acelera/blogmaker/controller/v1/PostController.java`, `src/main/java/org/acelera/blogmaker/model/dto/request/CreatePostRequest.java`) [[1]](diffhunk://#diff-590be08e8cfa709abfced9b762b547e90b9888ebc3a91d32aef949a30fb071c3R8-R12) [[2]](diffhunk://#diff-590be08e8cfa709abfced9b762b547e90b9888ebc3a91d32aef949a30fb071c3L30-R37) [[3]](diffhunk://#diff-5267ac7ce63a754ec1cb2eed6c6de2e2e11cef948b8763fa6f22395290207c87L4-L6) [[4]](diffhunk://#diff-5267ac7ce63a754ec1cb2eed6c6de2e2e11cef948b8763fa6f22395290207c87L15-R12)

### Atualizações de Testes:
* Refatorados os testes de integração e unitários do `PostService` para se alinharem à nova estrutura de `CreatePostRequest` e removidas as asserções referentes ao campo `userId`. (`src/test/java/org/acelera/blogmaker/service/integration/PostServiceIntegrationTest.java`, `src/test/java/org/acelera/blogmaker/service/unit/PostServiceTest.java`) [[1]](diffhunk://#diff-ca16f8cfbe133d4ace1b882f3f0a4ec6cd93685e374b0ea70ac5feb51dc3a709L17) [[2]](diffhunk://#diff-ca16f8cfbe133d4ace1b882f3f0a4ec6cd93685e374b0ea70ac5feb51dc3a709L30-R42) [[3]](diffhunk://#diff-ca16f8cfbe133d4ace1b882f3f0a4ec6cd93685e374b0ea70ac5feb51dc3a709L50-R82) [[4]](diffhunk://#diff-b0c0a018b1d08d703afcb377811909e68c6afc64b4ff2ebfb6a2cf86e4a278f3L6-R6) [[5]](diffhunk://#diff-b0c0a018b1d08d703afcb377811909e68c6afc64b4ff2ebfb6a2cf86e4a278f3L24-R34) [[6]](diffhunk://#diff-b0c0a018b1d08d703afcb377811909e68c6afc64b4ff2ebfb6a2cf86e4a278f3L58-R83)